### PR TITLE
Fix order of arguments in documentation

### DIFF
--- a/lib/Numeric/MCMC.hs
+++ b/lib/Numeric/MCMC.hs
@@ -56,7 +56,7 @@
 -- >     (sampleT (slice 2.0) (slice 3.0))
 -- >
 -- > main :: IO ()
--- > main = withSystemRandom . asGenIO $ mcmc 10000 [0, 0] rosenbrock transition
+-- > main = withSystemRandom . asGenIO $ mcmc 10000 [0, 0] transition rosenbrock
 --
 -- See the attached test suite for other examples.
 


### PR DESCRIPTION
The transition and target arguments in the Haddock docs are the wrong way around
